### PR TITLE
Add relief layer 

### DIFF
--- a/debug/relief.html
+++ b/debug/relief.html
@@ -43,15 +43,22 @@ map.on('load', function () {
         "id": "relief",
         "source": "gsi-dem",
         "type": "relief",
-        "layout": {
+        "paint": {
+            "relief-opacity": 0.7,
+            "relief-colors": [
+                0, "#2db4b4",
+                100, "#71b42d",
+                300, "#b4a72d",
+                1000, "#b4562d",
+                2000, "#b4491b",
+                null, "#b43d09"
+            ]
         }
     }, 'waterway-river-canal-shadow');
     map.addLayer({
         "id": "GSI dem",
         "source": "gsi-dem",
         "type": "hillshade",
-        "layout": {
-        }
     }, 'relief');
 });
 

--- a/debug/relief.html
+++ b/debug/relief.html
@@ -21,7 +21,8 @@
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/mapbox/cjaudgl840gn32rnrepcb9b9g', // the outdoors-v10 style but without Hillshade layers
+    style: 'mapbox://styles/tattii/cjq1bfwal3vc92rs01s7npew2', // the outdoors-v10 style but without Hillshade, Contour, Landcover layers
+    //style: 'mapbox://styles/tattii/cjq3r5dzi8y5s2sqk81yx85f0',
     center: [130.8537, 31.9288],
     zoom: 10,
 	hash: true
@@ -45,6 +46,7 @@ map.on('load', function () {
         "type": "relief",
         "paint": {
             "relief-opacity": 0.7,
+            "relief-gradation": true,
             "relief-colors": [
                 0, "#2db4b4",
                 100, "#71b42d",

--- a/debug/relief.html
+++ b/debug/relief.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mapbox GL JS debug page</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <link rel='stylesheet' href='/dist/mapbox-gl.css' />
+    <style>
+        body { margin: 0; padding: 0; }
+        html, body, #map { height: 100%; }
+    </style>
+</head>
+
+<body>
+
+<div id='map'></div>
+
+<script src='/dist/mapbox-gl-dev.js'></script>
+<script src='/debug/access_token_generated.js'></script>
+<script>
+
+var map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/cjaudgl840gn32rnrepcb9b9g', // the outdoors-v10 style but without Hillshade layers
+    center: [130.8537, 31.9288],
+    zoom: 10,
+	hash: true
+});
+
+map.on('load', function () {
+
+    map.addSource('gsi-dem', {
+        "type": "raster-dem",
+        "encoding": "gsi",
+        "tiles": [
+			"https://cyberjapandata.gsi.go.jp/xyz/dem_png/{z}/{x}/{y}.png"
+        ],
+        "tileSize": 256,
+		"maxzoom": 14,
+		"attribution": '<a href="https://maps.gsi.go.jp/development/ichiran.html#dem" target="_blank">地理院標高タイル</a>'
+    });
+    map.addLayer({
+        "id": "relief",
+        "source": "gsi-dem",
+        "type": "relief",
+        "layout": {
+        }
+    }, 'waterway-river-canal-shadow');
+    map.addLayer({
+        "id": "GSI dem",
+        "source": "gsi-dem",
+        "type": "hillshade",
+        "layout": {
+        }
+    }, 'relief');
+});
+
+
+</script>
+</body>
+</html>

--- a/src/data/dem_data.js
+++ b/src/data/dem_data.js
@@ -105,7 +105,7 @@ class DEMData {
         // int24 complement
         // sea surface = NA (2 ^ 23)
         let h = r * 256 * 256 + g * 256 + b;
-        return (h == Math.pow(2, 23)) ? 0 : 0.01 * ((h << 8) | 0) >> 8; // uint24 -> uint32 -> int32 -> int24
+        return (h == Math.pow(2, 23)) ? -65536 : 0.01 * ((h << 8) | 0) >> 8; // uint24 -> uint32 -> int32 -> int24
     }
 
     _unpackData(level: Level, pixels: Uint8Array | Uint8ClampedArray, encoding: string) {

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -5,16 +5,15 @@ const EXTENT = require('../data/extent');
 const mat4 = require('@mapbox/gl-matrix').mat4;
 const StencilMode = require('../gl/stencil_mode');
 const DepthMode = require('../gl/depth_mode');
-const {RGBAImage} = require('../util/image');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
-import type HillshadeStyleLayer from '../style/style_layer/hillshade_style_layer';
+import type ReliefStyleLayer from '../style/style_layer/relief_style_layer';
 import type {OverscaledTileID} from '../source/tile_id';
 
 module.exports = drawRelief;
 
-function drawRelief(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>) {
+function drawRelief(painter: Painter, sourceCache: SourceCache, layer: ReliefStyleLayer, tileIDs: Array<OverscaledTileID>) {
     if (painter.renderPass !== 'translucent') return;
 
     const context = painter.context;
@@ -27,7 +26,8 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
 
     // Constant parameters.
     gl.uniform1i(program.uniforms.u_image, 0);
-    gl.uniform1f(program.uniforms.u_opacity, 0.7);
+    const opacity = layer.paint.get("relief-opacity") || 0.7;
+    gl.uniform1f(program.uniforms.u_opacity, opacity);
     setReliefColor(context, gl, program, layer);
 
 
@@ -76,38 +76,15 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
 
 
 function setReliefColor(context, gl, program, layer) {
-    // const colors = layer.paint.get("relief-colors");
-    const colors = [
-        [0, [50, 180, 50]],
-        [10, [240, 250, 150]],
-        [30, [190, 185, 135]],
-        [60, [235, 220, 175]],
-        [100, [0, 100, 0]],
-        [500, [0, 0, 100]],
-        [1500, [0, 0, 200]]
-    ];
-
-    const len = colors.length;
-    const color_table = new Uint8Array(4 * len * 2);
-    const elevation_table = new Uint32Array(len);
-
-    for (let i = 0; i < len; i++){
-        elevation_table[i] = colors[i][0] + 65536;
-
-        color_table[4*i    ] = colors[i][1][0];
-        color_table[4*i + 1] = colors[i][1][1];
-        color_table[4*i + 2] = colors[i][1][2];
-    }
-    color_table.set(new Uint8Array(elevation_table.buffer), 4 * len);
+    const image = layer.colorRampImage;
 
     context.activeTexture.set(gl.TEXTURE1);
     context.pixelStoreUnpackPremultiplyAlpha.set(false);
-    const image = new RGBAImage({width: len, height: 2}, color_table);
     const texture = new Texture(context, image, gl.RGBA, false);
     texture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
 
     gl.uniform1i(program.uniforms.u_table, 1);
-    gl.uniform1f(program.uniforms.u_color_len, len);
+    gl.uniform1f(program.uniforms.u_color_len, image.width);
 }
 
 

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -45,10 +45,10 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
             if (tile.demTexture) {
                 const demTexture = tile.demTexture;
                 demTexture.update(pixelData, false);
-                demTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+                demTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
             } else {
                 tile.demTexture = new Texture(context, pixelData, gl.RGBA, false);
-                tile.demTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+                tile.demTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
             }
 
             // relief paint

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -17,7 +17,6 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
     if (painter.renderPass !== 'translucent') return;
 
     const context = painter.context;
-    const sourceMaxZoom = sourceCache.getSource().maxzoom;
 
     context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
     context.setStencilMode(StencilMode.disabled);
@@ -32,44 +31,73 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
 }
 
 
-function getTileLatRange(painter, tileID: OverscaledTileID) {
-    const coordinate0 = tileID.toCoordinate();
-    const coordinate1 = new Coordinate(coordinate0.column, coordinate0.row + 1, coordinate0.zoom);
-    return [painter.transform.coordinateLocation(coordinate0).lat, painter.transform.coordinateLocation(coordinate1).lat];
-}
-
 function renderRelief(painter, tile, layer) {
     const context = painter.context;
     const gl = context.gl;
-    const fbo = tile.fbo;
-    if (!fbo) return;
 
-    const program = painter.useProgram('relief');
-    const posMatrix = painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), true);
-    context.activeTexture.set(gl.TEXTURE0);
+    if (tile.dem && tile.dem.level) {
+        const tileSize = tile.dem.level.dim;
 
-    gl.bindTexture(gl.TEXTURE_2D, fbo.colorAttachment.get());
+        const pixelData = tile.dem.getPixels();
+        context.activeTexture.set(gl.TEXTURE1);
 
-    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
-    gl.uniform1i(program.uniforms.u_image, 0);
+        context.pixelStoreUnpackPremultiplyAlpha.set(false);
+        tile.demTexture = tile.demTexture || painter.getTileTexture(tile.tileSize);
+        if (tile.demTexture) {
+            const demTexture = tile.demTexture;
+            demTexture.update(pixelData, false);
+            demTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+        } else {
+            tile.demTexture = new Texture(context, pixelData, gl.RGBA, false);
+            tile.demTexture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+        }
 
-    const shadowColor = layer.paint.get("hillshade-shadow-color");
-    gl.uniform4f(program.uniforms.u_shadow, shadowColor.r, shadowColor.g, shadowColor.b, shadowColor.a);
+        context.activeTexture.set(gl.TEXTURE0);
 
-    if (tile.maskedBoundsBuffer && tile.maskedIndexBuffer && tile.segments) {
-        program.draw(
-            context,
-            gl.TRIANGLES,
-            layer.id,
-            tile.maskedBoundsBuffer,
-            tile.maskedIndexBuffer,
-            tile.segments
-        );
-    } else {
-        const buffer = painter.rasterBoundsBuffer;
-        const vao = painter.rasterBoundsVAO;
-        vao.bind(context, program, buffer, []);
-        gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+        let fbo = tile.fbo;
+
+        if (!fbo) {
+            const renderTexture = new Texture(context, {width: tileSize, height: tileSize, data: null}, gl.RGBA);
+            renderTexture.bind(gl.LINEAR, gl.CLAMP_TO_EDGE);
+
+            fbo = tile.fbo = context.createFramebuffer(tileSize, tileSize);
+            fbo.colorAttachment.set(renderTexture.texture);
+        }
+
+        context.bindFramebuffer.set(fbo.framebuffer);
+        context.viewport.set([0, 0, tileSize, tileSize]);
+
+        const matrix = mat4.create();
+        // Flip rendering at y axis.
+        mat4.ortho(matrix, 0, EXTENT, -EXTENT, 0, 0, 1);
+        mat4.translate(matrix, matrix, [0, -EXTENT, 0]);
+
+
+        // ----------------
+        const program = painter.useProgram('relief');
+        const posMatrix = painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), true);
+
+        gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
+        gl.uniform1i(program.uniforms.u_image, 1);
+
+        const shadowColor = layer.paint.get("hillshade-shadow-color");
+        gl.uniform4f(program.uniforms.u_shadow, shadowColor.r, shadowColor.g, shadowColor.b, shadowColor.a);
+
+        if (tile.maskedBoundsBuffer && tile.maskedIndexBuffer && tile.segments) {
+            program.draw(
+                context,
+                gl.TRIANGLES,
+                layer.id,
+                tile.maskedBoundsBuffer,
+                tile.maskedIndexBuffer,
+                tile.segments
+            );
+        } else {
+            const buffer = painter.rasterBoundsBuffer;
+            const vao = painter.rasterBoundsVAO;
+            vao.bind(context, program, buffer, []);
+            gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+        }
     }
 }
 

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -77,11 +77,12 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: ReliefSty
 
 function setReliefColor(context, gl, program, layer) {
     const image = layer.colorRampImage;
+    const gradation = true;
 
     context.activeTexture.set(gl.TEXTURE1);
     context.pixelStoreUnpackPremultiplyAlpha.set(false);
     const texture = new Texture(context, image, gl.RGBA, false);
-    texture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+    texture.bind((gradation) ? gl.LINEAR : gl.NEAREST, gl.CLAMP_TO_EDGE);
 
     gl.uniform1i(program.uniforms.u_table, 1);
     gl.uniform1f(program.uniforms.u_color_len, image.width);

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -77,7 +77,7 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: ReliefSty
 
 function setReliefColor(context, gl, program, layer) {
     const image = layer.colorRampImage;
-    const gradation = true;
+    const gradation = layer.paint.get("relief-gradation");
 
     context.activeTexture.set(gl.TEXTURE1);
     context.pixelStoreUnpackPremultiplyAlpha.set(false);

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -5,6 +5,7 @@ const EXTENT = require('../data/extent');
 const mat4 = require('@mapbox/gl-matrix').mat4;
 const StencilMode = require('../gl/stencil_mode');
 const DepthMode = require('../gl/depth_mode');
+const {RGBAImage} = require('../util/image');
 
 import type Painter from './painter';
 import type SourceCache from '../source/source_cache';
@@ -27,7 +28,7 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
     // Constant parameters.
     gl.uniform1i(program.uniforms.u_image, 0);
     gl.uniform1f(program.uniforms.u_opacity, 0.7);
-    setReliefColor(gl, program, layer);
+    setReliefColor(context, gl, program, layer);
 
 
     for (const tileID of tileIDs) {
@@ -74,23 +75,38 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
 }
 
 
-function setReliefColor(gl, program, layer) {
+function setReliefColor(context, gl, program, layer) {
     // const colors = layer.paint.get("relief-colors");
     const colors = [
         [0, [50, 180, 50]],
         [10, [240, 250, 150]],
         [30, [190, 185, 135]],
         [60, [235, 220, 175]],
+        [60, [0, 0, 175]],
         [100, [0, 100, 0]]
     ];
 
-    // assert max 128 colors
+    const len = colors.length;
+    const color_table = new Uint8Array(4 * len * 2);
+    const elevation_table = new Uint32Array(len);
 
-    const u_colors = colors.reduce(function(arr, d) {
-        return arr.concat([d[1][0] / 255, d[1][1] / 255, d[1][2] / 255, d[0]]);
-    }, []);
-    gl.uniform4fv(program.uniforms['u_colors[0]'], u_colors);
-    gl.uniform1i(program.uniforms.u_color_len, colors.length);
+    for (let i = 0; i < len; i++){
+        elevation_table[i] = colors[i][0] + 65536;
+
+        color_table[4*i    ] = colors[i][1][0];
+        color_table[4*i + 1] = colors[i][1][1];
+        color_table[4*i + 2] = colors[i][1][2];
+    }
+    color_table.set(new Uint8Array(elevation_table.buffer), 4 * len);
+
+    context.activeTexture.set(gl.TEXTURE1);
+    context.pixelStoreUnpackPremultiplyAlpha.set(false);
+    const image = new RGBAImage({width: len, height: 2}, color_table);
+    const texture = new Texture(context, image, gl.RGBA, false);
+    texture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
+
+    gl.uniform1i(program.uniforms.u_table, 1);
+    gl.uniform1i(program.uniforms.u_color_len, len);
 }
 
 

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -20,14 +20,14 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
     const gl = context.gl;
     const program = painter.useProgram('relief');
 
+    context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
     context.setStencilMode(StencilMode.disabled);
     context.setColorMode(painter.colorModeForRenderPass());
 
     // Constant parameters.
     gl.uniform1i(program.uniforms.u_image, 0);
     gl.uniform1f(program.uniforms.u_opacity, 0.7);
-    const shadowColor = layer.paint.get("hillshade-shadow-color");
-    gl.uniform4f(program.uniforms.u_shadow, shadowColor.r, shadowColor.g, shadowColor.b, shadowColor.a);
+    setReliefColor(gl, program, layer);
 
 
     for (const tileID of tileIDs) {
@@ -71,6 +71,26 @@ function drawRelief(painter: Painter, sourceCache: SourceCache, layer: Hillshade
             }
         }
     }
+}
+
+
+function setReliefColor(gl, program, layer) {
+    // const colors = layer.paint.get("relief-colors");
+    const colors = [
+        [0, [50, 180, 50]],
+        [10, [240, 250, 150]],
+        [30, [190, 185, 135]],
+        [60, [235, 220, 175]],
+        [100, [0, 100, 0]]
+    ];
+
+    // assert max 128 colors
+
+    const u_colors = colors.reduce(function(arr, d) {
+        return arr.concat([d[1][0] / 255, d[1][1] / 255, d[1][2] / 255, d[0]]);
+    }, []);
+    gl.uniform4fv(program.uniforms['u_colors[0]'], u_colors);
+    gl.uniform1i(program.uniforms.u_color_len, colors.length);
 }
 
 

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -82,8 +82,9 @@ function setReliefColor(context, gl, program, layer) {
         [10, [240, 250, 150]],
         [30, [190, 185, 135]],
         [60, [235, 220, 175]],
-        [60, [0, 0, 175]],
-        [100, [0, 100, 0]]
+        [100, [0, 100, 0]],
+        [500, [0, 0, 100]],
+        [1500, [0, 0, 200]]
     ];
 
     const len = colors.length;
@@ -106,7 +107,7 @@ function setReliefColor(context, gl, program, layer) {
     texture.bind(gl.NEAREST, gl.CLAMP_TO_EDGE);
 
     gl.uniform1i(program.uniforms.u_table, 1);
-    gl.uniform1i(program.uniforms.u_color_len, len);
+    gl.uniform1f(program.uniforms.u_color_len, len);
 }
 
 

--- a/src/render/draw_relief.js
+++ b/src/render/draw_relief.js
@@ -1,0 +1,76 @@
+// @flow
+const Coordinate = require('../geo/coordinate');
+const Texture = require('./texture');
+const EXTENT = require('../data/extent');
+const mat4 = require('@mapbox/gl-matrix').mat4;
+const StencilMode = require('../gl/stencil_mode');
+const DepthMode = require('../gl/depth_mode');
+
+import type Painter from './painter';
+import type SourceCache from '../source/source_cache';
+import type HillshadeStyleLayer from '../style/style_layer/hillshade_style_layer';
+import type {OverscaledTileID} from '../source/tile_id';
+
+module.exports = drawRelief;
+
+function drawRelief(painter: Painter, sourceCache: SourceCache, layer: HillshadeStyleLayer, tileIDs: Array<OverscaledTileID>) {
+    if (painter.renderPass !== 'translucent') return;
+
+    const context = painter.context;
+    const sourceMaxZoom = sourceCache.getSource().maxzoom;
+
+    context.setDepthMode(painter.depthModeForSublayer(0, DepthMode.ReadOnly));
+    context.setStencilMode(StencilMode.disabled);
+    context.setColorMode(painter.colorModeForRenderPass());
+
+    for (const tileID of tileIDs) {
+        const tile = sourceCache.getTile(tileID);
+        renderRelief(painter, tile, layer);
+    }
+
+    context.viewport.set([0, 0, painter.width, painter.height]);
+}
+
+
+function getTileLatRange(painter, tileID: OverscaledTileID) {
+    const coordinate0 = tileID.toCoordinate();
+    const coordinate1 = new Coordinate(coordinate0.column, coordinate0.row + 1, coordinate0.zoom);
+    return [painter.transform.coordinateLocation(coordinate0).lat, painter.transform.coordinateLocation(coordinate1).lat];
+}
+
+function renderRelief(painter, tile, layer) {
+    const context = painter.context;
+    const gl = context.gl;
+    const fbo = tile.fbo;
+    if (!fbo) return;
+
+    const program = painter.useProgram('relief');
+    const posMatrix = painter.transform.calculatePosMatrix(tile.tileID.toUnwrapped(), true);
+    context.activeTexture.set(gl.TEXTURE0);
+
+    gl.bindTexture(gl.TEXTURE_2D, fbo.colorAttachment.get());
+
+    gl.uniformMatrix4fv(program.uniforms.u_matrix, false, posMatrix);
+    gl.uniform1i(program.uniforms.u_image, 0);
+
+    const shadowColor = layer.paint.get("hillshade-shadow-color");
+    gl.uniform4f(program.uniforms.u_shadow, shadowColor.r, shadowColor.g, shadowColor.b, shadowColor.a);
+
+    if (tile.maskedBoundsBuffer && tile.maskedIndexBuffer && tile.segments) {
+        program.draw(
+            context,
+            gl.TRIANGLES,
+            layer.id,
+            tile.maskedBoundsBuffer,
+            tile.maskedIndexBuffer,
+            tile.segments
+        );
+    } else {
+        const buffer = painter.rasterBoundsBuffer;
+        const vao = painter.rasterBoundsVAO;
+        vao.bind(context, program, buffer, []);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, buffer.length);
+    }
+}
+
+

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -30,7 +30,7 @@ const draw = {
     fill: require('./draw_fill'),
     'fill-extrusion': require('./draw_fill_extrusion'),
     hillshade: require('./draw_hillshade'),
-    relief: require('./draw_hillshade'),
+    relief: require('./draw_relief'),
     raster: require('./draw_raster'),
     background: require('./draw_background'),
     debug: require('./draw_debug')

--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -30,6 +30,7 @@ const draw = {
     fill: require('./draw_fill'),
     'fill-extrusion': require('./draw_fill_extrusion'),
     hillshade: require('./draw_hillshade'),
+    relief: require('./draw_hillshade'),
     raster: require('./draw_raster'),
     background: require('./draw_background'),
     debug: require('./draw_debug')

--- a/src/shaders/hillshade_prepare.fragment.glsl
+++ b/src/shaders/hillshade_prepare.fragment.glsl
@@ -11,7 +11,8 @@ uniform float u_maxzoom;
 float getElevation(vec2 coord, float bias) {
     // Convert encoded elevation value to meters
     vec4 data = texture2D(u_image, coord) * 255.0;
-    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0) / 4.0;
+    float v = (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
+	return (v > 0.0 ? v : 65536.0) / 4.0; // use 0.0 as NA
 }
 
 void main() {

--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -82,6 +82,10 @@ const shaders: {[string]: {fragmentSource: string, vertexSource: string}} = {
         fragmentSource: fs.readFileSync(__dirname + '/../shaders/hillshade.fragment.glsl', 'utf8'),
         vertexSource: fs.readFileSync(__dirname + '/../shaders/hillshade.vertex.glsl', 'utf8')
     },
+    relief: {
+        fragmentSource: fs.readFileSync(__dirname + '/../shaders/relief.fragment.glsl', 'utf8'),
+        vertexSource: fs.readFileSync(__dirname + '/../shaders/relief.vertex.glsl', 'utf8')
+    },
     line: {
         fragmentSource: fs.readFileSync(__dirname + '/../shaders/line.fragment.glsl', 'utf8'),
         vertexSource: fs.readFileSync(__dirname + '/../shaders/line.vertex.glsl', 'utf8')

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -1,7 +1,9 @@
 uniform sampler2D u_image;
 varying vec2 v_pos;
 
-uniform vec4 u_shadow;
+uniform vec4 u_colors[128];
+uniform int u_color_len;
+uniform float u_opacity;
 
 float getElevation(vec2 coord) {
     // Convert encoded elevation value to meters
@@ -11,9 +13,10 @@ float getElevation(vec2 coord) {
 
 
 void main() {
-	float v = getElevation(v_pos);
+    float v = getElevation(v_pos);
 
-    gl_FragColor =  v > 100.0 ? u_shadow : vec4(1.0, 1.0, 1.0, 1.0);
+    vec4 c = u_colors[2];
+    gl_FragColor =  v > 100.0 ? vec4(0.0, 0.2, 0.0, u_opacity) : vec4(c.rgb, u_opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -1,3 +1,7 @@
+#ifdef GL_ES
+precision highp float;
+#endif
+
 uniform sampler2D u_image;
 uniform sampler2D u_table;
 varying vec2 v_pos;
@@ -8,7 +12,7 @@ uniform float u_opacity;
 float getElevation(sampler2D u_tex, vec2 coord, float bias) {
     // Convert encoded elevation value to meters
     vec4 data = texture2D(u_tex, coord) * 255.0;
-    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
+    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0) / 4.0;
 }
 
 float getIndex(float el) {

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -18,7 +18,7 @@ float getIndex(float el) {
 		float v = getElevation(u_table, vec2((i + 0.5) / u_color_len, 1), 0.0);
 		if (v >= el){
 			if (i == 0.0) return i;
-			return i - 1.0 + (el - prev) / (v - prev);
+			return i + (el - prev) / (v - prev);
 		}
 		prev = v;
     }

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -12,23 +12,23 @@ float getElevation(sampler2D u_tex, vec2 coord, float bias) {
 }
 
 float getIndex(float el) {
-	float prev;
+    float prev;
     for (float i = 0.0; i < 128.0; i++){
-		if (i >= u_color_len) return u_color_len;
-		float v = getElevation(u_table, vec2((i + 0.5) / u_color_len, 1), 0.0);
-		if (v >= el){
-			if (i == 0.0) return i;
-			return i + (el - prev) / (v - prev);
-		}
-		prev = v;
+        if (i >= u_color_len) return u_color_len;
+        float v = getElevation(u_table, vec2((i + 0.5) / u_color_len, 1), 0.0);
+        if (v >= el){
+            if (i == 0.0) return i;
+            return i + (el - prev) / (v - prev);
+        }
+        prev = v;
     }
 }
 
 void main() {
     float v = getElevation(u_image, v_pos, 0.0);
-	float i = getIndex(v);
+    float i = getIndex(v);
 
-	vec4 color = texture2D(u_table, vec2(i / u_color_len, 0), 0.0);
+    vec4 color = texture2D(u_table, vec2(i / u_color_len, 0), 0.0);
     gl_FragColor = v > 0.0 ? vec4(color.rgb, u_opacity) : vec4(0.0, 0.0, 0.0, 0.0);
 
 #ifdef OVERDRAW_INSPECTOR

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -5,28 +5,21 @@ varying vec2 v_pos;
 uniform float u_color_len;
 uniform float u_opacity;
 
-float getElevation0(vec2 coord) {
+float getElevation(sampler2D u_tex, vec2 coord, float bias) {
     // Convert encoded elevation value to meters
-    vec4 data = texture2D(u_image, coord) * 255.0;
-    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
-}
-
-float getElevation1(vec2 coord, float bias) {
-    // Convert encoded elevation value to meters
-    vec4 data = texture2D(u_table, coord) * 255.0;
+    vec4 data = texture2D(u_tex, coord) * 255.0;
     return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
 }
 
 float getIndex(float v) {
     for (float i = 0.0; i < 128.0; i++){
 		if (i >= u_color_len) return u_color_len - 1.0;
-		if (getElevation1(vec2(i / u_color_len, 1), 0.0) >= v) return i;
+		if (getElevation(u_table, vec2(i / u_color_len, 1), 0.0) >= v) return i;
     }
 }
 
-
 void main() {
-    float v = getElevation0(v_pos);
+    float v = getElevation(u_image, v_pos, 0.0);
 	float i = getIndex(v);
 
 	vec4 color = texture2D(u_table, vec2(i / u_color_len, 0), 0.0);

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -23,7 +23,7 @@ void main() {
 	float i = getIndex(v);
 
 	vec4 color = texture2D(u_table, vec2(i / u_color_len, 0), 0.0);
-    gl_FragColor = vec4(color.rgb, u_opacity);
+    gl_FragColor = v > 0.0 ? vec4(color.rgb, u_opacity) : vec4(0.0, 0.0, 0.0, 0.0);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -1,0 +1,20 @@
+uniform sampler2D u_image;
+varying vec2 v_pos;
+
+uniform vec2 u_latrange;
+uniform vec2 u_light;
+uniform vec4 u_shadow;
+uniform vec4 u_highlight;
+uniform vec4 u_accent;
+
+#define PI 3.141592653589793
+
+void main() {
+    vec4 pixel = texture2D(u_image, v_pos);
+
+    gl_FragColor = u_shadow;
+
+#ifdef OVERDRAW_INSPECTOR
+    gl_FragColor = vec4(1.0);
+#endif
+}

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -1,27 +1,36 @@
 uniform sampler2D u_image;
+uniform sampler2D u_table;
 varying vec2 v_pos;
 
-uniform vec4 u_colors[128];
-uniform int u_color_len;
+uniform float u_color_len;
 uniform float u_opacity;
 
-float getElevation(vec2 coord) {
+float getElevation0(vec2 coord) {
     // Convert encoded elevation value to meters
     vec4 data = texture2D(u_image, coord) * 255.0;
-    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0) - 65536.0;
+    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
+}
+
+float getElevation1(vec2 coord, float bias) {
+    // Convert encoded elevation value to meters
+    vec4 data = texture2D(u_table, coord) * 255.0;
+    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
+}
+
+float getIndex(float v) {
+    for (float i = 0.0; i < 128.0; i++){
+		if (i >= u_color_len) return u_color_len - 1.0;
+		if (getElevation1(vec2(i / u_color_len, 1), 0.0) >= v) return i;
+    }
 }
 
 
 void main() {
-    float v = getElevation(v_pos);
+    float v = getElevation0(v_pos);
+	float i = getIndex(v);
 
-	int k;	
-    for (int i = 0; i < 128; i++){
-		k = i;
-        if (u_colors[i].a >= v) break;
-    }
-
-    gl_FragColor = vec4(u_colors[i].rgb, u_opacity);
+	vec4 color = texture2D(u_table, vec2(i / u_color_len, 0), 0.0);
+    gl_FragColor = vec4(color.rgb, u_opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -15,8 +15,13 @@ float getElevation(vec2 coord) {
 void main() {
     float v = getElevation(v_pos);
 
-    vec4 c = u_colors[2];
-    gl_FragColor =  v > 100.0 ? vec4(0.0, 0.2, 0.0, u_opacity) : vec4(c.rgb, u_opacity);
+	int k;	
+    for (int i = 0; i < 128; i++){
+		k = i;
+        if (u_colors[i].a >= v) break;
+    }
+
+    gl_FragColor = vec4(u_colors[i].rgb, u_opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -1,18 +1,19 @@
 uniform sampler2D u_image;
 varying vec2 v_pos;
 
-uniform vec2 u_latrange;
-uniform vec2 u_light;
 uniform vec4 u_shadow;
-uniform vec4 u_highlight;
-uniform vec4 u_accent;
 
-#define PI 3.141592653589793
+float getElevation(vec2 coord) {
+    // Convert encoded elevation value to meters
+    vec4 data = texture2D(u_image, coord) * 255.0;
+    return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0) - 65536.0;
+}
+
 
 void main() {
-    vec4 pixel = texture2D(u_image, v_pos);
+	float v = getElevation(v_pos);
 
-    gl_FragColor = u_shadow;
+    gl_FragColor =  v > 100.0 ? u_shadow : vec4(1.0, 1.0, 1.0, 1.0);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/relief.fragment.glsl
+++ b/src/shaders/relief.fragment.glsl
@@ -11,10 +11,16 @@ float getElevation(sampler2D u_tex, vec2 coord, float bias) {
     return (data.r + data.g * 256.0 + data.b * 256.0 * 256.0);
 }
 
-float getIndex(float v) {
+float getIndex(float el) {
+	float prev;
     for (float i = 0.0; i < 128.0; i++){
-		if (i >= u_color_len) return u_color_len - 1.0;
-		if (getElevation(u_table, vec2(i / u_color_len, 1), 0.0) >= v) return i;
+		if (i >= u_color_len) return u_color_len;
+		float v = getElevation(u_table, vec2((i + 0.5) / u_color_len, 1), 0.0);
+		if (v >= el){
+			if (i == 0.0) return i;
+			return i - 1.0 + (el - prev) / (v - prev);
+		}
+		prev = v;
     }
 }
 

--- a/src/shaders/relief.vertex.glsl
+++ b/src/shaders/relief.vertex.glsl
@@ -1,0 +1,11 @@
+uniform mat4 u_matrix;
+
+attribute vec2 a_pos;
+attribute vec2 a_texture_pos;
+
+varying vec2 v_pos;
+
+void main() {
+    gl_Position = u_matrix * vec4(a_pos, 0, 1);
+    v_pos = a_texture_pos / 8192.0;
+}

--- a/src/shaders/relief.vertex.glsl
+++ b/src/shaders/relief.vertex.glsl
@@ -7,5 +7,5 @@ varying vec2 v_pos;
 
 void main() {
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
-    v_pos = a_texture_pos / 8192.0;
+    v_pos = (a_texture_pos / 8192.0) / 2.0 + 0.25;
 }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -2389,6 +2389,7 @@
     "paint_symbol",
     "paint_raster",
     "paint_hillshade",
+    "paint_relief",
     "paint_background"
   ],
   "paint_fill": {
@@ -3939,6 +3940,44 @@
         "sdk-support": {
           "basic functionality": {
             "js": "0.43.0"
+          },
+          "data-driven styling": {}
+        }
+      }
+  },
+  "paint_relief": {
+      "relief-opacity": {
+        "type": "number",
+        "doc": "",
+        "default": 0.7,
+        "minimum": 0,
+        "maximum": 1,
+        "function": "interpolated",
+        "zoom-function": true,
+        "transition": true,
+        "sdk-support": {
+          "basic functionality": {
+            "js": "---"
+          },
+          "data-driven styling": {}
+        }
+      },
+      "relief-colors": {
+        "type": "array",
+        "value": "*",
+        "default": [
+          0, "rgba(0, 0, 255, 0)",
+          10, "royalblue",
+          100, "red"
+        ],
+        "doc": "",
+        "function": "interpolated",
+        "zoom-function": false,
+        "property-function": false,
+        "transition": false,
+        "sdk-support": {
+          "basic functionality": {
+            "js": "---"
           },
           "data-driven styling": {}
         }

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -525,6 +525,14 @@
             }
           }
         },
+        "relief": {
+          "doc": "",
+          "sdk-support": {
+            "basic functionality": {
+              "js": "---"
+            }
+          }
+        },
         "background": {
           "doc": "The background color or pattern of the map.",
           "sdk-support": {

--- a/src/style-spec/reference/v8.json
+++ b/src/style-spec/reference/v8.json
@@ -3962,6 +3962,19 @@
           "data-driven styling": {}
         }
       },
+      "relief-gradation": {
+        "type": "boolean",
+        "function": "piecewise-constant",
+        "zoom-function": false,
+        "default": true,
+        "doc": "",
+        "sdk-support": {
+          "basic functionality": {
+            "js": "---"
+          },
+          "data-driven styling": {}
+        }
+      },
       "relief-colors": {
         "type": "array",
         "value": "*",

--- a/src/style-spec/validate/validate_layer.js
+++ b/src/style-spec/validate/validate_layer.js
@@ -66,7 +66,7 @@ module.exports = function validateLayer(options) {
                 errors.push(new ValidationError(key, layer.source, `layer "${layer.id}" requires a vector source`));
             } else if (sourceType === 'vector' && !layer['source-layer']) {
                 errors.push(new ValidationError(key, layer, `layer "${layer.id}" must specify a "source-layer"`));
-            } else if (sourceType === 'raster-dem' && type !== 'hillshade') {
+            } else if (sourceType === 'raster-dem' && (type !== 'hillshade' && type !== 'relief')) {
                 errors.push(new ValidationError(key, layer.source, 'raster-dem source can only be used with layer type \'hillshade\'.'));
             }
         }

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -210,7 +210,7 @@ const subclasses = {
     'circle': require('./style_layer/circle_style_layer'),
     'heatmap': require('./style_layer/heatmap_style_layer'),
     'hillshade': require('./style_layer/hillshade_style_layer'),
-    'relief': require('./style_layer/hillshade_style_layer'),
+    'relief': require('./style_layer/relief_style_layer'),
     'fill': require('./style_layer/fill_style_layer'),
     'fill-extrusion': require('./style_layer/fill_extrusion_style_layer'),
     'line': require('./style_layer/line_style_layer'),

--- a/src/style/style_layer.js
+++ b/src/style/style_layer.js
@@ -210,6 +210,7 @@ const subclasses = {
     'circle': require('./style_layer/circle_style_layer'),
     'heatmap': require('./style_layer/heatmap_style_layer'),
     'hillshade': require('./style_layer/hillshade_style_layer'),
+    'relief': require('./style_layer/hillshade_style_layer'),
     'fill': require('./style_layer/fill_style_layer'),
     'fill-extrusion': require('./style_layer/fill_extrusion_style_layer'),
     'line': require('./style_layer/line_style_layer'),

--- a/src/style/style_layer/relief_style_layer.js
+++ b/src/style/style_layer/relief_style_layer.js
@@ -1,0 +1,24 @@
+// @flow
+
+const StyleLayer = require('../style_layer');
+const properties = require('./relief_style_layer_properties');
+
+const {
+    Transitionable,
+    Transitioning,
+    PossiblyEvaluated
+} = require('../properties');
+
+import type {PaintProps} from './relief_style_layer_properties';
+
+class HillshadeStyleLayer extends StyleLayer {
+    _transitionablePaint: Transitionable<PaintProps>;
+    _transitioningPaint: Transitioning<PaintProps>;
+    paint: PossiblyEvaluated<PaintProps>;
+
+    constructor(layer: LayerSpecification) {
+        super(layer, properties);
+    }
+}
+
+module.exports = HillshadeStyleLayer;

--- a/src/style/style_layer/relief_style_layer.js
+++ b/src/style/style_layer/relief_style_layer.js
@@ -2,6 +2,8 @@
 
 const StyleLayer = require('../style_layer');
 const properties = require('./relief_style_layer_properties');
+const Color = require('../../style-spec/util/color');
+const {RGBAImage} = require('../../util/image');
 
 const {
     Transitionable,
@@ -11,14 +13,43 @@ const {
 
 import type {PaintProps} from './relief_style_layer_properties';
 
-class HillshadeStyleLayer extends StyleLayer {
+class ReliefStyleLayer extends StyleLayer {
     _transitionablePaint: Transitionable<PaintProps>;
     _transitioningPaint: Transitioning<PaintProps>;
     paint: PossiblyEvaluated<PaintProps>;
 
     constructor(layer: LayerSpecification) {
         super(layer, properties);
+        this._updateColorRamp();
+    }
+
+    setPaintProperty(name: string, value: mixed, options: {validate: boolean}) {
+        super.setPaintProperty(name, value, options);
+        if (name === 'relief-colors') {
+            this._updateColorRamp(value);
+        }
+    }
+
+    _updateColorRamp(colors) {
+        if (!colors) return;
+        const len = colors.length / 2;
+        const color_table = new Uint8Array(4 * len * 2);
+        const elevation_table = new Uint32Array(len);
+
+        for (let i = 0; i < len; i++){
+            const el = colors[2*i];
+            const color = Color.parse(colors[2*i + 1]);
+
+            elevation_table[i] = (el != null) ? el + 65536 : Math.pow(2, 32) - 1; // null as MAX
+
+            color_table[4*i    ] = Math.floor(color.r * 255);
+            color_table[4*i + 1] = Math.floor(color.g * 255);
+            color_table[4*i + 2] = Math.floor(color.b * 255);
+        }
+        
+        color_table.set(new Uint8Array(elevation_table.buffer), 4 * len);
+        this.colorRampImage = new RGBAImage({width: len, height: 2}, color_table);
     }
 }
 
-module.exports = HillshadeStyleLayer;
+module.exports = ReliefStyleLayer;

--- a/src/style/style_layer/relief_style_layer_properties.js
+++ b/src/style/style_layer/relief_style_layer_properties.js
@@ -1,0 +1,28 @@
+// This file is generated. Edit build/generate-style-code.js, then run `yarn run codegen`.
+// @flow
+/* eslint-disable */
+
+const styleSpec = require('../../style-spec/reference/latest');
+
+const {
+    Properties,
+    DataConstantProperty,
+    DataDrivenProperty,
+    CrossFadedProperty,
+    HeatmapColorProperty
+} = require('../properties');
+
+import type Color from '../../style-spec/util/color';
+
+
+export type PaintProps = {|
+    "relief-opacity": DataConstantProperty<number>,
+    "relief-colors": DataConstantProperty<Color>,
+|};
+
+const paint: Properties<PaintProps> = new Properties({
+    "relief-opacity": new DataConstantProperty(styleSpec["paint_relief"]["relief-opacity"]),
+    "relief-colors": new DataConstantProperty(styleSpec["paint_relief"]["relief-colors"]),
+});
+
+module.exports = { paint };

--- a/src/style/style_layer/relief_style_layer_properties.js
+++ b/src/style/style_layer/relief_style_layer_properties.js
@@ -17,11 +17,13 @@ import type Color from '../../style-spec/util/color';
 
 export type PaintProps = {|
     "relief-opacity": DataConstantProperty<number>,
+    "relief-gradation": DataConstantProperty<boolean>,
     "relief-colors": HeatmapColorProperty,
 |};
 
 const paint: Properties<PaintProps> = new Properties({
     "relief-opacity": new DataConstantProperty(styleSpec["paint_relief"]["relief-opacity"]),
+    "relief-gradation": new DataConstantProperty(styleSpec["paint_relief"]["relief-gradation"]),
     "relief-colors": new HeatmapColorProperty(styleSpec["paint_relief"]["relief-colors"]),
 });
 

--- a/src/style/style_layer/relief_style_layer_properties.js
+++ b/src/style/style_layer/relief_style_layer_properties.js
@@ -17,12 +17,12 @@ import type Color from '../../style-spec/util/color';
 
 export type PaintProps = {|
     "relief-opacity": DataConstantProperty<number>,
-    "relief-colors": DataConstantProperty<Color>,
+    "relief-colors": HeatmapColorProperty,
 |};
 
 const paint: Properties<PaintProps> = new Properties({
     "relief-opacity": new DataConstantProperty(styleSpec["paint_relief"]["relief-opacity"]),
-    "relief-colors": new DataConstantProperty(styleSpec["paint_relief"]["relief-colors"]),
+    "relief-colors": new HeatmapColorProperty(styleSpec["paint_relief"]["relief-colors"]),
 });
 
 module.exports = { paint };


### PR DESCRIPTION
Add relief layer, coloring from raster-dem source.

demo https://tattii.github.io/terrain-japan/relief/#9.06/35.511/139.1993

exapmle
```
map.addLayer({
    "id": "relief",
    "source": "gsi-dem",
    "type": "relief",
    "paint": {
        "relief-opacity": 0.7,
        "relief-gradation": true,
        "relief-colors": [
            0, "#2db4b4",
            100, "#71b42d",
            300, "#b4a72d",
            1000, "#b4562d",
            2000, "#b4491b",
            4000, "#b43d09",
            null, "#b43d09"
        ]
    }
});
```